### PR TITLE
Fix tests on external PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,7 @@ name: "CodeQL"
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '33 11 * * 3'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@
 #
 name: Test
 
-on: [push]
+on: [push, pull_request]
 
 # This test runs on a remote server, so we need to do a lot of
 # low-level preparation before we can run the NPM test.


### PR DESCRIPTION
Tests did not run on PRs from branches in forked repositories, which blocked them from being merged. This should be fixed now.